### PR TITLE
Enhance TLS certificate management by introducing a shared TLS store …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 certs
 uploads
 backups
+volumes/tls-certs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,14 +12,12 @@ services:
     environment:
       - DOMAIN=${DOMAIN}
       - MQTT_TLS_DOMAIN=${MQTT_TLS_DOMAIN:-${DOMAIN}}
-      - LE_LIVE_DIR=/etc/letsencrypt/live
     volumes:
-      # Shared config volume (rw): mosquitto.conf, acl, passwd live here
       - ./volumes/mmdvm-mqtt:/mosquitto/config
-      # Persistence volume (rw) kept separate to avoid overlapping mounts
       - ./volumes/mmdvm-mqtt-data:/mosquitto/data
       - ./server/mmdvm-link:/init:ro
-      - /etc/letsencrypt:/etc/letsencrypt:ro
+      # Shared TLS store (provisioned by update.sh; GID 1000 can read key)
+      - ./volumes/tls-certs:/etc/tls:ro
     networks:
       - trac-network
     restart: unless-stopped

--- a/docs/TLS-FOR-SERVICES.md
+++ b/docs/TLS-FOR-SERVICES.md
@@ -1,0 +1,37 @@
+# TLS sertifikası kullanan servisler
+
+Tüm stack için tek bir TLS sertifika deposu kullanılır. Yeni bir servis TLS istiyorsa aynı yapıyı kullanır; sertifikayı kendisi kopyalamaz veya özel izin çözümü yapmaz.
+
+## Nasıl çalışır
+
+1. **update.sh** (deploy sırasında) `/etc/letsencrypt/live/${DOMAIN}/` içeriğini `./volumes/tls-certs/` dizinine kopyalar.
+2. İzinler: `fullchain.pem` 644, `privkey.pem` 640; sahip `root:1000`. Yani **GID 1000** olan her process key dosyasını okuyabilir.
+3. Servisler bu dizini **read-only** mount eder ve process’i **UID 1000, GID 1000** (veya en azından GID 1000) ile çalıştırır.
+
+## Yeni servise TLS ekleme
+
+1. **docker-compose.yml** içinde servise volume ekle:
+   ```yaml
+   volumes:
+     - ./volumes/tls-certs:/etc/tls:ro
+   ```
+
+2. Sertifika yolları:
+   - Cert: `/etc/tls/fullchain.pem`
+   - Key: `/etc/tls/privkey.pem`
+
+3. Process’in bu dosyaları okuyabilmesi için:
+   - Container’ı `user: "1000:1000"` ile çalıştırın, **veya**
+   - Entrypoint root ile başlayıp config/data için gerekli chown’ları yaptıktan sonra `runuser`/`su` ile UID 1000 GID 1000’e düşün (örnek: `server/mmdvm-link/mosquitto-entrypoint.sh`).
+
+4. İsteğe bağlı env (update.sh ile uyumlu):
+   - `TLS_CERTS_UID=1000` / `TLS_CERTS_GID=1000` (varsayılan 1000; farklı kullanacaksanız update.sh’deki `TLS_CERTS_GID` ile aynı değeri kullanın).
+
+## Özet
+
+| Ne            | Nerede / Nasıl |
+|---------------|-----------------|
+| Depo yolu     | `./volumes/tls-certs` (host), container’da örn. `/etc/tls` |
+| Provisioning  | `update.sh` (DOMAIN ve LetsEncrypt cert varken) |
+| Key okuma     | Process GID 1000 (veya `TLS_CERTS_GID`) ile çalışmalı |
+| Örnek         | Mosquitto: `server/mmdvm-link/mosquitto-entrypoint.sh` |

--- a/server/mmdvm-link/mosquitto-entrypoint.sh
+++ b/server/mmdvm-link/mosquitto-entrypoint.sh
@@ -1,77 +1,52 @@
 #!/bin/sh
 set -eu
 
-# Single-container bootstrap for Mosquitto config stored on a shared volume.
-# - Ensures /mosquitto/config/{mosquitto.conf,acl,passwd} exist (idempotent)
-# - Validates LetsEncrypt cert/key at /etc/letsencrypt/live/${DOMAIN}/fullchain.pem + privkey.pem
-# - Does NOT copy config elsewhere: Mosquitto reads live files from /mosquitto/config
-
-DOMAIN="${DOMAIN:-}"
-TLS_DOMAIN="${MQTT_TLS_DOMAIN:-${DOMAIN}}"
-
-LE_LIVE_DIR="${LE_LIVE_DIR:-/etc/letsencrypt/live}"
-CERTFILE="$LE_LIVE_DIR/$TLS_DOMAIN/fullchain.pem"
-KEYFILE="$LE_LIVE_DIR/$TLS_DOMAIN/privkey.pem"
+# Mosquitto bootstrap: uses shared TLS store at /etc/tls (provisioned by update.sh).
+# Runs as UID/GID 1000 so it can read the key (group 1000). No per-service cert copy.
 
 CONF_PATH="/mosquitto/config/mosquitto.conf"
 ACL_PATH="/mosquitto/config/acl"
 PASSWD_PATH="/mosquitto/config/passwd"
+# Shared store: fullchain.pem and privkey.pem, readable by GID 1000
+CERTFILE="/etc/tls/fullchain.pem"
+KEYFILE="/etc/tls/privkey.pem"
+TLS_UID="${TLS_CERTS_UID:-1000}"
+TLS_GID="${TLS_CERTS_GID:-1000}"
 
 umask 077
 
 mkdir -p /mosquitto/config /mosquitto/data
 
-if [ -z "$TLS_DOMAIN" ]; then
-  echo "ERROR: DOMAIN not set; required for TLS cert validation." >&2
-  exit 1
-fi
-
 if [ ! -f "$CERTFILE" ] || [ ! -f "$KEYFILE" ]; then
-  echo "ERROR: Missing TLS cert/key for domain '$TLS_DOMAIN'." >&2
+  echo "ERROR: Shared TLS store missing. Run update.sh to provision ./volumes/tls-certs." >&2
   echo "Expected: $CERTFILE and $KEYFILE" >&2
   exit 1
 fi
 
-# External listener uses password auth; ensure passwd file exists (may be empty).
 if [ ! -f "$PASSWD_PATH" ]; then
-  : >"$PASSWD_PATH"
-  chmod 600 "$PASSWD_PATH" || true
+  touch "$PASSWD_PATH"
 fi
 
-# Ensure Mosquitto can read/write its own state on the mounted volumes.
-# TLS certs under /etc/letsencrypt remain root-owned; mosquitto process will run as root
-# (container user 0:0, no "user" directive in config) so it can read them.
-chown -R mosquitto:mosquitto /mosquitto/config /mosquitto/data 2>/dev/null || true
-chmod 700 /mosquitto/config /mosquitto/data 2>/dev/null || true
-chmod 600 "$PASSWD_PATH" 2>/dev/null || true
-
-if [ ! -s "$ACL_PATH" ]; then
-  cat >"$ACL_PATH" <<'EOF'
+cat >"$ACL_PATH" <<'ACLEOF'
 pattern write nodes/telemetry/%u
 pattern write nodes/status/%u
 topic write nodes/register
 pattern read nodes/cmd/%u
 pattern read nodes/register/ack/%u
-EOF
-fi
+ACLEOF
 
-if [ ! -s "$CONF_PATH" ]; then
-  cat >"$CONF_PATH" <<EOF
+cat >"$CONF_PATH" <<CONFEOF
 per_listener_settings true
 
-# Internal listener (no auth/acl). Network-only; do NOT publish to host.
 listener 1883
 protocol mqtt
 listener_allow_anonymous true
 
-# External listener (TLS-only) published to host.
 listener 8883
 protocol mqtt
-
 listener_allow_anonymous false
-password_file /mosquitto/config/passwd
-acl_file /mosquitto/config/acl
-
+password_file $PASSWD_PATH
+acl_file $ACL_PATH
 certfile $CERTFILE
 keyfile $KEYFILE
 require_certificate false
@@ -81,8 +56,15 @@ persistence_location /mosquitto/data/
 autosave_interval 60
 
 log_dest stdout
-EOF
+CONFEOF
+
+chown -R "${TLS_UID}:${TLS_GID}" /mosquitto/config /mosquitto/data
+chmod 755 /mosquitto/config /mosquitto/data
+chmod 600 "$PASSWD_PATH"
+chmod 644 "$ACL_PATH" "$CONF_PATH"
+
+# Drop to TLS_UID:TLS_GID so process can read shared cert store (key is chmod 640, group TLS_GID)
+if command -v runuser >/dev/null 2>&1; then
+  exec runuser -u "$TLS_UID" -g "$TLS_GID" -- mosquitto -c "$CONF_PATH"
 fi
-
-exec mosquitto -c /mosquitto/config/mosquitto.conf
-
+exec su "$TLS_UID" -s /bin/sh -c "exec mosquitto -c $CONF_PATH"

--- a/update.sh
+++ b/update.sh
@@ -11,6 +11,14 @@ warn() { echo -e "${YELLOW}[$(date '+%H:%M:%S')]${NC} $1"; }
 
 # Expect to be run from same directory as docker-compose.yml (e.g. /opt/trac)
 
+# Load .env so DOMAIN (and TLS cert path) is available for shared cert store
+if [ -f .env ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source ./.env 2>/dev/null || true
+  set +a
+fi
+
 # Use last-deployed tags from .versions when not set (e.g. manual run or after reboot)
 if [ -z "${UI_TAG:-}" ] || [ -z "${API_TAG:-}" ]; then
   if [ -f .versions ]; then
@@ -41,6 +49,22 @@ echo ""
 log "Ön temizlik..."
 docker image prune -f 2>/dev/null || true
 docker builder prune -f 2>/dev/null || true
+
+# Shared TLS cert store: any service that needs TLS mounts ./volumes/tls-certs and runs as GID 1000
+TLS_STORE="${TLS_CERTS_DIR:-./volumes/tls-certs}"
+TLS_GID="${TLS_CERTS_GID:-1000}"
+if [ -n "${DOMAIN:-}" ] && [ -f "/etc/letsencrypt/live/${DOMAIN}/fullchain.pem" ] && [ -f "/etc/letsencrypt/live/${DOMAIN}/privkey.pem" ]; then
+  log "TLS sertifika deposu güncelleniyor ($TLS_STORE)..."
+  mkdir -p "$TLS_STORE"
+  cp -f "/etc/letsencrypt/live/${DOMAIN}/fullchain.pem" "$TLS_STORE/fullchain.pem"
+  cp -f "/etc/letsencrypt/live/${DOMAIN}/privkey.pem" "$TLS_STORE/privkey.pem"
+  chown -R "root:${TLS_GID}" "$TLS_STORE"
+  chmod 644 "$TLS_STORE/fullchain.pem"
+  chmod 640 "$TLS_STORE/privkey.pem"
+else
+  [ -z "${DOMAIN:-}" ] && warn "DOMAIN boş; TLS deposu atlanıyor." || true
+  [ -n "${DOMAIN:-}" ] && [ ! -f "/etc/letsencrypt/live/${DOMAIN}/fullchain.pem" ] && warn "LetsEncrypt sertifikası yok; TLS deposu atlanıyor." || true
+fi
 
 log "Yeni imajlar çekiliyor..."
 # Always update core services


### PR DESCRIPTION
…in the update script and updating Mosquitto entrypoint to utilize it. Modify docker-compose.yml to mount the new TLS volume and update .gitignore to include the new volume path.